### PR TITLE
Fix integer constant token

### DIFF
--- a/Finishing Off The Grammar-Parser-part2/parser.y
+++ b/Finishing Off The Grammar-Parser-part2/parser.y
@@ -24,7 +24,7 @@
 %token<int_val> ADDOP MULOP DIVOP INCR OROP ANDOP NOTOP EQUOP RELOP
 %token<int_val> LPAREN RPAREN LBRACK RBRACK LBRACE RBRACE SEMI DOT COMMA ASSIGN REFER
 %token <symtab_item>   ID
-%token <int_val>       CONST
+%token <int_val>       ICONST
 %token <double_val>    FCONST
 %token <char_val>      CCONST
 %token <str_val>       STRING


### PR DESCRIPTION
Hey, thanks for the tutorial series.
I found a small bug in one of the tokens in the parser.

```shell
parser.y:124.11-16: error: symbol ‘ICONST’ is used, but is not defined as a token and has no rules; did you mean ‘CONST’?
  124 | constant: ICONST | FCONST | CCONST ;
      |           ^~~~~~
      |           CONST
cc1: fatal error: parser.tab.c: No such file or directory
compilation terminated.
lexer.l:8:18: fatal error: parser.tab.h: No such file or directory
    8 |         #include "parser.tab.h"
      |                  ^~~~~~~~~~~~~~
compilation terminated.
```